### PR TITLE
Removed multiprocessing

### DIFF
--- a/erd/render.py
+++ b/erd/render.py
@@ -1,37 +1,30 @@
-from multiprocessing import Process
 import sys
 
 from pygraphviz import AGraph
 
 from .templates import GRAPH_BEGINNING
 
-def run_graph(dot, format, output_path='output.png'):
+
+def run_graph(dot, format, output_path="output.png"):
     graph = AGraph()
     graph = graph.from_string(dot)
-    graph.draw(path=output_path, prog='dot', format=format)
-    sys.exit(0)
-    
-def render(objects, output_path=None, format='png') -> str:
-    e = '\n'.join(e.to_dot() for e in objects['entities'])
-    r = ''
-    for idx, rel in enumerate(objects['relationships'], start=1):
-        r = r + rel.to_dot(flip=idx % 2 == 0) + '\n'
-    # r = '\n'.join(rel.to_dot() for r in objects['relationships'])
-    dot = f'{GRAPH_BEGINNING}\n{e}\n{r}\n}}\n'
+    graph.draw(path=output_path, prog="dot", format=format)
 
-    if format == 'png':
-        p = Process(target=run_graph, args=(dot, format, output_path))
-        p.start()
-        p.join()
-        assert p.exitcode == 0
+
+def render(objects, output_path=None, format="png") -> str:
+    e = "\n".join(e.to_dot() for e in objects["entities"])
+    r = ""
+    for idx, rel in enumerate(objects["relationships"], start=1):
+        r = r + rel.to_dot(flip=idx % 2 == 0) + "\n"
+    dot = f"{GRAPH_BEGINNING}\n{e}\n{r}\n}}\n"
+
+    if format == "png":
+        run_graph(dot, format, output_path)
         return output_path
     else:
         if output_path:
-            with open(output_path, 'w') as f:
+            with open(output_path, "w") as f:
                 f.write(dot)
             return output_path
         else:
             return dot
-
-
-


### PR DESCRIPTION
Removed mulitprocessing lines to get around error:
 This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:
            if __name__ == '__main__':
                freeze_support()
                ...
        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.